### PR TITLE
three minor bug fixes (saving data, saving plots)

### DIFF
--- a/analysis/ev_case_study/plot_overall_cost.py
+++ b/analysis/ev_case_study/plot_overall_cost.py
@@ -41,9 +41,9 @@ def plot_overall_cost(overall_costs, save_figure=True, figure_path='figures/'):
     plt.legend(bbox_to_anchor=(1.1, 0.5), loc="center right", borderaxespad=0.2)
     # Save
     plt.tight_layout()
-    plt.show()  # -> optional
     if save_figure:
         plt.savefig(figure_path + 'total_charging_cost' + '.png', dpi=600)
+    plt.show()  # -> optional
 
 
 if __name__ == '__main__':

--- a/analysis/ev_case_study/plot_timeseries_results.py
+++ b/analysis/ev_case_study/plot_timeseries_results.py
@@ -106,7 +106,7 @@ def plot_n_avail_veh(output_path, save_figure=True, figure_path='../figures/'):
     # print('Maximum number of available vehicles:', opt_per_daytime['n_veh_avail'].max())
 
 
-def plot_opt_flex_timeseries(cs1_output_path, cs2_output_path, save_figure=True, figure_path='../figures/'):
+def plot_opt_flex_timeseries(power, cs1_output_path, cs2_output_path, save_figure=True, figure_path='../figures/'):
     """
     This function plots the flexibility results of two case studies over time
 
@@ -114,6 +114,7 @@ def plot_opt_flex_timeseries(cs1_output_path, cs2_output_path, save_figure=True,
     :param cs1_output_path: path to results of the first case study
     :param cs2_output_path: path to results of the second case study
     :param figure_path: folder where figures are stored
+    :param power: current power level
     :return:
     """
 
@@ -594,16 +595,17 @@ def plot_opt_flex_timeseries(cs1_output_path, cs2_output_path, save_figure=True,
     axs[0, 0].set_xticklabels(resulting_labels, rotation=45)
     plt.subplots_adjust(left=0.08, bottom=0.05, right=0.98, top=0.95, wspace=0.25, hspace=0.2)
     if save_figure:
-        plt.savefig(figure_path + 'opt_flex_average_day_plots.png', dpi=600)
+        plt.savefig(figure_path + str(power) + '_opt_flex_average_day_plots.png', dpi=600)
 
 
-def plot_opt_flex_timeseries(output_path, save_figure=True, figure_path='figures/'):
+def plot_opt_flex_timeseries(power, output_path, save_figure=True, figure_path='figures/'):
     """
     This function plots the flexibility results of a study over time
 
     :param save_figure: boolean whether to save figure or not
     :param output_path: path to results of the  case study
     :param figure_path: folder where figures are stored
+    :param power: current power level
     :return:
     """
 
@@ -809,7 +811,7 @@ def plot_opt_flex_timeseries(output_path, save_figure=True, figure_path='figures
     axs[0, 0].set_xticklabels(resulting_labels, rotation=45)
     plt.subplots_adjust(left=0.08, bottom=0.05, right=0.98, top=0.95, wspace=0.25, hspace=0.2)
     if save_figure:
-        plt.savefig(figure_path + 'opt_flex_average_day_plots.png', dpi=600)
+        plt.savefig(figure_path + str(power) + '_opt_flex_average_day_plots.png', dpi=600)
 
 
 if __name__ == '__main__':

--- a/analysis/run_ev_case_study.py
+++ b/analysis/run_ev_case_study.py
@@ -95,7 +95,7 @@ for power in power_levels:
     overall_costs[power]['Con_mi'] = pd.read_hdf(output_path + str(power) + '/Aggregated Data/opt_sum_data.h5')['c_con_mi_energy'].sum()
     overall_costs[power]['RTP'] = pd.read_hdf(output_path + str(power) + '/Aggregated Data/opt_sum_data.h5')['c_rtp_energy'].sum()
     # Plot aggregated flexibility offers over time
-    ev_case_study.plot_opt_flex_timeseries(output_path=output_path + str(power) + '/', figure_path=figure_path)
+    ev_case_study.plot_opt_flex_timeseries(power, output_path=output_path + str(power) + '/', figure_path=figure_path)
 
 # Plot overall cost
 ev_case_study.plot_overall_cost(overall_costs=overall_costs, figure_path=figure_path)

--- a/opentumflex/market_communication/generate_market_offers.py
+++ b/opentumflex/market_communication/generate_market_offers.py
@@ -52,7 +52,7 @@ def save_offers_comax(my_ems,  device,  filetype='xlsx'):
     new_cwd = os.path.join(path, file_name)
     
     # Save flex offers in the requested format
-    if filetype == '.xlsx':
+    if filetype == 'xlsx':
         my_ems['flexopts'][device].to_excel(new_cwd+'.xlsx')
         # print("Excel file generated! Available on " + path)
     elif filetype == 'csv':


### PR DESCRIPTION
three minor bug fixes for the follwing:
- saving data to xlsx file: erased "." in filetype specification, that prevented saving as xlsx
- saving overall cost plot: call plt.show() after savefig, so that now the plot is saved, not a blank .png-file
- saving all three timeseries plots: Before, all three plots were saved to the same path, resulting in overwriting the file and only saving the last plot. By adding the parameter power to the plot_opt_flex_timeseries function definitions and passing the power level as an argument when calling the function in run_ev_case_study - the power level can now be added to the figure path. Therefore all three figures are now saved, as the power level is included in the figure filename. The new parameter was also added to the function docstrings.
